### PR TITLE
chore: SixLabors.ImageSharp version bump from 2.1.0 to 2.1.7

### DIFF
--- a/ResourceFileEditor/ResourceFileEditor.csproj
+++ b/ResourceFileEditor/ResourceFileEditor.csproj
@@ -25,7 +25,7 @@
 	
   <ItemGroup>
     <PackageReference Include="BCnEncoder.Net45" Version="0.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
     <PackageReference Include="StbImageSharp" Version="2.27.8" />
     <PackageReference Include="StbImageWriteSharp" Version="1.13.5" />
   </ItemGroup>


### PR DESCRIPTION
closes #11